### PR TITLE
Allow users to select only certain package managers to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 att: main.c
-	gcc -Wall -Wextra -ansi -pedantic -std=c99 -o att main.c
+	gcc -Wall -Wextra -ansi -pedantic -std=gnu99 -o att main.c
 install:
 	cp att /usr/local/bin
 uninstall:

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,7 @@ $ att search emacs # Search all managers for a package
 $ att search --exact emacs # This is an exact search
 $ att upgrade # Update and upgrade all packages in all managers
 $ att clean # Clean packages in all managers
+$ att clean --managers=apt,flatpak # Only clean packages in apt and flatpak
 ```
 
 Note: Only package managers that are installed on your system will attempt to run, in order to reduce output and noise.


### PR DESCRIPTION
Sometimes you might just want to do something in one manager. Now you can.

Fixes #4 